### PR TITLE
avoid leaking decrypted secret in logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version="0.4.0"
+version="0.4.1"
 encryption_key=${CONFIG_ENCRYPTION_KEY}
 set_private_repos :
 	go get github.com/cognitedata/cognite-sdk-go

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,7 +148,7 @@ func startEdgeExtractor(mainConfigPath string) {
 		return
 	}
 
-	log.Infof("Starting edge-extractor service. Secret = %s", config.Secret)
+	log.Info("Starting edge-extractor service.")
 
 	cdfCLient := internal.NewCdfClient(config.ProjectName, config.CdfCluster, config.ClientID, config.Secret, config.Scopes, config.AdTenantId, config.AuthTokenUrl, config.CdfDatasetID)
 


### PR DESCRIPTION
Not sure if any other files need to be updated to be able to build a new version? 

Also, if it is easy, maybe we can add the version to the end of the executable name